### PR TITLE
Windowsで動かない問題の修正

### DIFF
--- a/src/META-INF/MANIFEST.MF
+++ b/src/META-INF/MANIFEST.MF
@@ -1,0 +1,3 @@
+Manifest-Version: 1.0
+Main-Class: net.trpfrog.medipro_game.MediproGame
+

--- a/src/net/trpfrog/medipro_game/util/ResourceLoader.java
+++ b/src/net/trpfrog/medipro_game/util/ResourceLoader.java
@@ -1,8 +1,7 @@
 package net.trpfrog.medipro_game.util;
 
 import java.awt.*;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Path;
@@ -11,27 +10,19 @@ import javax.imageio.ImageIO;
 
 public class ResourceLoader {
 
-    private static boolean useOuterResourceFolder = false;
-
     private static String toClassLoaderReadablePath(String path) {
         if(path.startsWith(".")) {
             path = path.substring(1);
         }
-        System.err.println(path);
-        return path;
+        return path.replace(File.separatorChar, '/');
     }
 
     public static Image readImage(String path) {
         try {
             return ImageIO.read(getInputStream(path));
         } catch (IOException | IllegalArgumentException e) {
-            if(useOuterResourceFolder) {
-                e.printStackTrace();
-                return null;
-            } else {
-                useOuterResourceFolder = true;
-                return readImage(path);
-            }
+            e.printStackTrace();
+            return null;
         }
     }
 
@@ -44,17 +35,8 @@ public class ResourceLoader {
     }
 
     public static InputStream getInputStream(String path) {
-        if(useOuterResourceFolder) {
-            try {
-                return new FileInputStream(path);
-            } catch (FileNotFoundException e) {
-                e.printStackTrace();
-            }
-        } else {
-            path = toClassLoaderReadablePath(path);
-            return ResourceLoader.class.getResourceAsStream(path);
-        }
-        return null;
+        path = toClassLoaderReadablePath(path);
+        return ResourceLoader.class.getResourceAsStream(path);
     }
 
     public static InputStream getInputStream(Path path) {


### PR DESCRIPTION
パスの区切りに `File.separatorChar` を使うのをやめ、`/` で統一することにより修正しました。
close #305 